### PR TITLE
rename deprecated assertEquals to assertEqual

### DIFF
--- a/imsvdex/tests/testConverters.py
+++ b/imsvdex/tests/testConverters.py
@@ -62,25 +62,25 @@ class Conversions(unittest.TestCase):
                 "",
             ],
         ]
-        self.assertEquals(should_be, data)
+        self.assertEqual(should_be, data)
 
     def testMatrixImport(self):
         with resource_stream(__name__, "test.xml") as f:
             manager = VDEXManager(f)
         matrix = manager.exportMatrix()
         new_manager = VDEXManager(matrix=matrix)
-        self.assertEquals(matrix, new_manager.exportMatrix())
+        self.assertEqual(matrix, new_manager.exportMatrix())
 
         data = new_manager.serialize()
         should_be_xml = u'<?xml version="1.0" encoding="utf-8" ?>\n<vdex xmlns="http://www.imsglobal.org/xsd/imsvdex_v1p0"><term><termIdentifier>identical</termIdentifier><caption><langstring language="en">is identical with</langstring><langstring language="fr">est identique avec</langstring><langstring language="it">è identico con</langstring></caption></term><term><termIdentifier>relative</termIdentifier><caption><langstring language="de">ist verwandt mit</langstring><langstring language="en">is relative of</langstring><langstring language="fr">est parent avec</langstring><langstring language="it">è parente di</langstring></caption><term><termIdentifier>child</termIdentifier><caption><langstring language="de">ist Kind von</langstring><langstring language="en">is child of</langstring><langstring language="fr">est enfant de</langstring><langstring language="it">è prole di</langstring></caption></term></term></vdex>'.encode("utf8")
         obj = objectify.fromstring(should_be_xml)
         should_be = etree.tostring(obj, encoding="utf-8", standalone=True)
-        self.assertEquals(should_be, data)
+        self.assertEqual(should_be, data)
 
     def testEmptyMatrix(self):
         manager = VDEXManager()
         matrix = manager.exportMatrix()
-        self.assertEquals([], matrix)
+        self.assertEqual([], matrix)
 
     def testOldSyntax(self):
         xml = ""


### PR DESCRIPTION
The assertEquals alias for assertEqual was deprecated in Python 3. In Python 3.12 it fails completely. This change renames the calls to assertEqual.